### PR TITLE
Adding the ability to adjust Event Hub timeout

### DIFF
--- a/docs/Sinks.md
+++ b/docs/Sinks.md
@@ -145,7 +145,8 @@ Provides functionality to write to Azure Event Hubs
   {
     "type": "AzureEventHub",
     "connectionString": "{CONECTIONSTRING}",
-    "eventBatchSizeInBytes": 131072
+    "eventBatchSizeInBytes": 131072,
+    "operationTimeoutMs": 60000
   }
 ]
 ```
@@ -158,6 +159,7 @@ Provides functionality to write to Azure Event Hubs
 |type|AzureEventHub|Specifies the sink type of AzureEventHub|
 |connectionString|String value|Connection string for the desired Event Hub where payloads get written to. Supports retrieving secret from environment variable using `env:MY_ENV_VAR_NAME` as the connectionString value.|
 |eventBatchSizeInBytes|long value|How large the batch size is that gets sent to Event Hubs|
+|operationTimeoutMs (Optional)|Int value|Sets the Event Hub client timeout in milliseconds, **Default 60000**|
 
 ---
 

--- a/src/DSynth.Common/DSynth.Common.csproj
+++ b/src/DSynth.Common/DSynth.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>osx-x64;linux-x64;win-x64;linux-arm64</RuntimeIdentifiers>
-    <Version>12.0.0.1</Version>
+    <Version>12.1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DSynth.Engine.Tests/DSynth.Engine.Tests.csproj
+++ b/src/DSynth.Engine.Tests/DSynth.Engine.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>osx-x64;linux-x64;win-x64;linux-arm64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
-    <Version>12.0.0.1</Version>
+    <Version>12.1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DSynth.Engine/DSynth.Engine.csproj
+++ b/src/DSynth.Engine/DSynth.Engine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>osx-x64;linux-x64;win-x64;linux-arm64</RuntimeIdentifiers>
-    <Version>12.0.0.1</Version>
+    <Version>12.1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DSynth.Provider/DSynth.Provider.csproj
+++ b/src/DSynth.Provider/DSynth.Provider.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>osx-x64;linux-x64;win-x64;linux-arm64</RuntimeIdentifiers>
-    <Version>12.0.0.1</Version>
+    <Version>12.1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DSynth.Reporter/DSynth.Reporter.csproj
+++ b/src/DSynth.Reporter/DSynth.Reporter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>osx-x64;linux-x64;win-x64;linux-arm64</RuntimeIdentifiers>
-    <Version>12.0.0.1</Version>
+    <Version>12.1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DSynth.Sink/DSynth.Sink.csproj
+++ b/src/DSynth.Sink/DSynth.Sink.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>osx-x64;linux-x64;win-x64;linux-arm64</RuntimeIdentifiers>
-    <Version>12.0.0.1</Version>
+    <Version>12.1.0.0</Version>
 
     <runtime>
       <gcServer enabled="true" />

--- a/src/DSynth.Sink/Options/AzureEventHubOptions.cs
+++ b/src/DSynth.Sink/Options/AzureEventHubOptions.cs
@@ -18,9 +18,11 @@ namespace DSynth.Sink.Options
         [JsonIgnore]
         public string ConnectionString => EvaluateAndRetrieveValue(_connectionString);
 
-
         [JsonProperty("eventBatchSizeInBytes")]
         public long EventBatchSizeInBytes { get; set; }
+
+        [JsonProperty("operationTimeoutMs")]
+        public int OperationTimeoutMs { get; set; } = 60000;
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
@@ -36,6 +38,10 @@ namespace DSynth.Sink.Options
             if (EventBatchSizeInBytes <= 0)
             {
                 yield return new ValidationResult("EventBatchSizeInBytes must be > 0");
+            }
+            if (OperationTimeoutMs <= 0)
+            {
+                yield return new ValidationResult("OperationTimeoutMs must be > 0");
             }
         }
     }

--- a/src/DSynth.Sink/Sinks/AzureEventHub.cs
+++ b/src/DSynth.Sink/Sinks/AzureEventHub.cs
@@ -28,7 +28,12 @@ namespace DSynth.Sink.Sinks
             _eventDataBatch = new EventDataBatch(_options.EventBatchSizeInBytes);
             _eventDataBatchFull += HandleEventDataBatchFull;
 
-            _client = EventHubClient.CreateFromConnectionString(_options.ConnectionString);
+            EventHubsConnectionStringBuilder csb = new EventHubsConnectionStringBuilder(_options.ConnectionString)
+            {
+                OperationTimeout = TimeSpan.FromMilliseconds(_options.OperationTimeoutMs)
+            };
+
+            _client = EventHubClient.Create(csb);
             _client.RetryPolicy = RetryPolicy.Default;
         }
 

--- a/src/DSynth/DSynth.csproj
+++ b/src/DSynth/DSynth.csproj
@@ -7,7 +7,7 @@
     <PublishSingleFile>true</PublishSingleFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
-    <Version>12.0.0.1</Version>
+    <Version>12.1.0.0</Version>
 
     <runtime>
       <gcServer enabled="true" />


### PR DESCRIPTION
The default is 60 seconds and sometimes the client could take longer and will result in an exception. Adding the option for the end user to adjust as necessary.

https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions#timeoutexception
