### PR TITLE
Throwing on other Azure Blob exceptions

### DIFF
--- a/src/DSynth.Sink/Sinks/AzureBlob.cs
+++ b/src/DSynth.Sink/Sinks/AzureBlob.cs
@@ -88,6 +88,10 @@ namespace DSynth.Sink.Sinks
                     await _lazyClient.Value.CreateIfNotExistsAsync().ConfigureAwait(false);
                     Logger.LogInformation(_infoBlobContainerCreated, Options.BlobContainerName);
                 }
+                else
+                {
+                    throw;
+                }
             }
         }
     }


### PR DESCRIPTION
Currently we ignore any exceptions other than container not existing. This is not the intended behavior and we need to throw this to the main sink event handler to get logged.