### PR TITLE
Fixing max and min

### DIFF
--- a/src/DSynth.Engine/TokenHandlers/NumberHandler.cs
+++ b/src/DSynth.Engine/TokenHandlers/NumberHandler.cs
@@ -83,15 +83,13 @@ namespace DSynth.Engine.TokenHandlers
             double ret = 0.0;
             if (_trackedDict.TryGetValue(_formattedTrackedKey, out double lastValue))
             {
-                if (lastValue >= _endAt)
-                    return _endAt;
-
                 if (!TokenHandlerHelpers.ShouldDeviate(_replacementWeight))
                     return lastValue;
 
                 double nextIncrement = TokenHandlerHelpers.GetNextRandomNumber(_minRange, _maxRange);
                 ret = lastValue += nextIncrement;
                 ret = ret >= _endAt ? _endAt : ret;
+                ret = ret <= _startAt ? _startAt : ret;
                 _trackedDict[_formattedTrackedKey] = ret;
             }
             else


### PR DESCRIPTION
# Description
Fixing an issue where the max value always get returned when a negative number is part of the token range. Also fixed an issue where the returned value would fall below the min value.

This was tested and charted to visualize:
![image](https://user-images.githubusercontent.com/25066231/179022814-66861da4-5295-4bea-aed9-b1822b5fb8f1.png)
